### PR TITLE
New user created from web interface

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2010-2015 by David E. Jones - jonesde
 Written in 2015 by Sam Hamilton - samhamilton
+Written in 2015 by Jens Hardings - jenshp

--- a/screen/HiveMindAdmin/User/EditUser.xml
+++ b/screen/HiveMindAdmin/User/EditUser.xml
@@ -43,6 +43,24 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
         <default-response url="."/>
     </transition>
+    <transition name="addUser">
+        <actions>
+            <entity-find-one entity-name="PersonAndUserAccount" value-field="personAndUserAccount"/>
+            <service-call name="create#moqui.security.UserGroupMember" in-map="[userGroupId:'HIVE_MIND_USERS',
+                    userId:personAndUserAccount.userId, fromDate:ec.user.nowTimestamp]"/>
+        </actions>
+        <default-response url="."/>
+    </transition>
+    <transition name="removeUser">
+        <actions>
+            <entity-find-one entity-name="PersonAndUserAccount" value-field="personAndUserAccount"/>
+            <entity-delete-by-condition entity-name="moqui.security.UserGroupMember">
+                <econdition field-name="userGroupId" value="HIVE_MIND_USERS"/>
+                <econdition field-name="userId" from="personAndUserAccount.userId"/>
+            </entity-delete-by-condition>
+        </actions>
+        <default-response url="."/>
+    </transition>
 
     <actions>
         <entity-find-one entity-name="mantle.party.PersonAndUserAccount" value-field="personAndUserAccount"/>
@@ -76,6 +94,10 @@ along with this software (see the LICENSE.md file). If not, see
                 <section name="UserAdminSection"><condition><expression>ec.user.isInGroup(personAndUserAccount.userId, "HIVE_MIND_ADMIN", null, ec)</expression></condition>
                     <widgets><link url="removeAdmin" text="Remove from Admin Group" link-type="hidden-form" parameter-map="[partyId:partyId]"/></widgets>
                     <fail-widgets><link url="addAdmin" text="Add to Admin Group" link-type="hidden-form" parameter-map="[partyId:partyId]"/></fail-widgets>
+                </section>
+                <section name="UserUseSection"><condition><expression>ec.user.isInGroup(personAndUserAccount.userId, "HIVE_MIND_USERS", null, ec)</expression></condition>
+                    <widgets><link url="removeUser" text="Remove from User Group" link-type="hidden-form" parameter-map="[partyId:partyId]"/></widgets>
+                    <fail-widgets><link url="addUser" text="Add to User Group" link-type="hidden-form" parameter-map="[partyId:partyId]"/></fail-widgets>
                 </section>
 
                 <form-single name="EditUser" transition="updateUser" map="personAndUserAccount">

--- a/screen/HiveMindAdmin/User/FindUser.xml
+++ b/screen/HiveMindAdmin/User/FindUser.xml
@@ -20,7 +20,10 @@ along with this software (see the LICENSE.md file). If not, see
 
     <transition name="findUser"><default-response url="."/></transition>
     <transition name="createUser">
-        <service-call name="mantle.party.PartyServices.create#Account" in-map="context + [loginAfterCreate:'false']"/>
+        <actions>
+        <service-call name="mantle.party.PartyServices.create#Account" in-map="context + [loginAfterCreate:'false']" out-map="context"/>
+        <service-call name="create#moqui.security.UserGroupMember" in-map="[userGroupId:'HIVE_MIND_USERS', userId:context.userId, fromDate:ec.user.nowTimestamp]"/>
+        </actions>
         <default-response url="../EditUser"/>
         <error-response url="."/>
     </transition>


### PR DESCRIPTION
When adding a user in the HiveMind admin (/apps/hmadmin/User/FindUser), add this user to the HIVE_MIND_USERS group by default.
Add a button to remove/add users to the HIVE_MIND_USERS group, just as we can add/remove users from the HIVE_MIND_ADMIN group.