### PR TITLE
Fixed absolute URLs that failed when moqui mounted at different location

### DIFF
--- a/screen/HiveMindAdmin/Project/EditWikiPages.xml
+++ b/screen/HiveMindAdmin/Project/EditWikiPages.xml
@@ -74,10 +74,10 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="wikiPageId"><default-field><hidden/></default-field></field>
 
             <field name="wikiSpaceId"><default-field title="Space"><display text=""/>
-                <link text="${wikiSpaceId}" url="/apps/hm/wiki/${wikiSpaceId}" url-type="plain"/>
+                <link text="${wikiSpaceId}" url="/apps/hm/wiki/${wikiSpaceId}"/>
             </default-field></field>
             <field name="pagePath"><default-field title="Page"><display text=""/>
-                <link text="${pagePath}" url="/apps/hm/wiki/${wikiSpaceId}/${pagePath?:''}" url-type="plain"/>
+                <link text="${pagePath}" url="/apps/hm/wiki/${wikiSpaceId}/${pagePath?:''}"/>
             </default-field></field>
 
             <field name="submitButton"><default-field title="Delete"><submit/></default-field></field>

--- a/screen/HiveMindAdmin/WikiSpace/EditWikiSpace.xml
+++ b/screen/HiveMindAdmin/WikiSpace/EditWikiSpace.xml
@@ -32,7 +32,7 @@ along with this software (see the LICENSE.md file). If not, see
     </actions>
     <widgets>
         <container>
-            <link text="View Space" url="/apps/hm/wiki/${wikiSpaceId}" url-type="plain" link-type="anchor-button"/>
+            <link text="View Space" url="/apps/hm/wiki/${wikiSpaceId}" link-type="anchor-button"/>
             <link text="Index Space Pages" url="indexPages" link-type="hidden-form"/>
         </container>
         <form-single name="EditSpace" transition="updateSpace">

--- a/screen/HiveMindAdmin/WikiSpace/FindWikiSpace.xml
+++ b/screen/HiveMindAdmin/WikiSpace/FindWikiSpace.xml
@@ -70,7 +70,7 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="restrictUpdate"><default-field><display also-hidden="false"/></default-field></field>
 
             <field name="viewSpaceLink"><default-field title="View">
-                <link text="View" url="/apps/hm/wiki/${wikiSpaceId}" url-type="plain"/>
+                <link text="View" url="/apps/hm/wiki/${wikiSpaceId}"/>
             </default-field></field>
         </form-list>
     </widgets>

--- a/screen/HiveMindRoot/Project/ProjectSummary.xml
+++ b/screen/HiveMindRoot/Project/ProjectSummary.xml
@@ -160,10 +160,10 @@ along with this software (see the LICENSE.md file). If not, see
                     <field name="wikiPageId"><default-field><hidden/></default-field></field>
 
                     <field name="wikiSpaceId"><default-field title="Wiki Space"><display text=""/>
-                        <link text="${wikiSpaceId}" url="/apps/hm/wiki/${wikiSpaceId}" url-type="plain"/>
+                        <link text="${wikiSpaceId}" url="/apps/hm/wiki/${wikiSpaceId}"/>
                     </default-field></field>
                     <field name="pagePath"><default-field title="Page"><display text=""/>
-                        <link text="${pagePath}" url="/apps/hm/wiki/${wikiSpaceId}/${pagePath?:''}" url-type="plain"/>
+                        <link text="${pagePath}" url="/apps/hm/wiki/${wikiSpaceId}/${pagePath?:''}"/>
                     </default-field></field>
                 </form-list>
 

--- a/screen/HiveMindRoot/Request/EditWikiPages.xml
+++ b/screen/HiveMindRoot/Request/EditWikiPages.xml
@@ -69,10 +69,10 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="wikiPageId"><default-field><hidden/></default-field></field>
 
             <field name="wikiSpaceId"><default-field title="Space"><display text=""/>
-                <link text="${wikiSpaceId}" url="/apps/hm/wiki/${wikiSpaceId}" url-type="plain" link-type="anchor"/>
+                <link text="${wikiSpaceId}" url="/apps/hm/wiki/${wikiSpaceId}" link-type="anchor"/>
             </default-field></field>
             <field name="pagePath"><default-field title="Page"><display text=""/>
-                <link text="${pagePath}" url="/apps/hm/wiki/${wikiSpaceId}/${pagePath?:''}" url-type="plain" link-type="anchor"/>
+                <link text="${pagePath}" url="/apps/hm/wiki/${wikiSpaceId}/${pagePath?:''}" link-type="anchor"/>
             </default-field></field>
 
             <field name="submitButton"><default-field title="Delete"><submit/></default-field></field>

--- a/screen/HiveMindRoot/Task/EditWikiPages.xml
+++ b/screen/HiveMindRoot/Task/EditWikiPages.xml
@@ -69,10 +69,10 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="wikiPageId"><default-field><hidden/></default-field></field>
 
             <field name="wikiSpaceId"><default-field title="Space"><display text=""/>
-                <link text="${wikiSpaceId}" url="/apps/hm/wiki/${wikiSpaceId}" url-type="plain" link-type="anchor"/>
+                <link text="${wikiSpaceId}" url="/apps/hm/wiki/${wikiSpaceId}" link-type="anchor"/>
             </default-field></field>
             <field name="pagePath"><default-field title="Page"><display text=""/>
-                <link text="${pagePath}" url="/apps/hm/wiki/${wikiSpaceId}/${pagePath?:''}" url-type="plain" link-type="anchor"/>
+                <link text="${pagePath}" url="/apps/hm/wiki/${wikiSpaceId}/${pagePath?:''}" link-type="anchor"/>
             </default-field></field>
 
             <field name="submitButton"><default-field title="Delete"><submit/></default-field></field>

--- a/screen/HiveMindRoot/Task/TaskSummary.xml
+++ b/screen/HiveMindRoot/Task/TaskSummary.xml
@@ -433,8 +433,8 @@ along with this software (see the LICENSE.md file). If not, see
                     <box-body>
                         <section-iterate name="TaskWikiPageList" list="wpaweList" entry="wpawe">
                             <widgets><container>
-                                <link text="${wpawe.wikiSpaceId}" url="/apps/hm/wiki/${wpawe.wikiSpaceId}" url-type="plain" link-type="anchor"/>
-                                <link text="/${wpawe.pagePath}" url="/apps/hm/wiki/${wpawe.wikiSpaceId}/${wpawe.pagePath?:''}" url-type="plain" link-type="anchor"/>
+                                <link text="${wpawe.wikiSpaceId}" url="/apps/hm/wiki/${wpawe.wikiSpaceId}" link-type="anchor"/>
+                                <link text="/${wpawe.pagePath}" url="/apps/hm/wiki/${wpawe.wikiSpaceId}/${wpawe.pagePath?:''}" link-type="anchor"/>
                             </container></widgets>
                         </section-iterate>
                     </box-body>

--- a/screen/HiveMindRoot/wiki.xml
+++ b/screen/HiveMindRoot/wiki.xml
@@ -141,7 +141,7 @@ along with this software (see the LICENSE.md file). If not, see
                             </script>
                             <set field="newIdPath" value="${treeNodeId == '#' ? '' : treeNodeId + '/'}${curFileName}"/>
                         </actions>
-                        <link text="${curFileName}" url="/apps/hm/wiki/${wikiSpaceId}/${newIdPath}" url-type="plain" id="${newIdPath}"/>
+                        <link text="${curFileName}" url="/apps/hm/wiki/${wikiSpaceId}/${newIdPath}" id="${newIdPath}"/>
                         <tree-sub-node node-name="WikiPageNode" list="childPageList">
                             <actions>
                                 <service-call name="HiveMind.WikiServices.get#WikiPageInfo" out-map="curPageInfo"


### PR DESCRIPTION
When Moqui is mounted at a different location than root, links that use the absolute URL, like "/apps/hm/wiki/..." fail.

While using relative URLs fixes the problem, in this case I changed the url-type to the default (screen-path) by eliminating the url-type="plain" attribute which seems to be a more robust solution.