### PR TITLE
Fix URL in Quick Search.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,7 +36,7 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2010-2016 by David E. Jones - jonesde
 Written in 2015 by Sam Hamilton - samhamilton
-Written in 2015 by Jens Hardings - jenshp
+Written in 2015-2016 by Jens Hardings - jenshp
 Written in 2015 by Yao Chunlin - chunlinyao
 
 ===========================================================================
@@ -61,5 +61,5 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2010-2016 by David E. Jones - jonesde
 Written in 2015 by Yao Chunlin - chunlinyao
-Written in 2015 by Jens Hardings - jenshp
+Written in 2015-2016 by Jens Hardings - jenshp
 Written in 2015 by Sam Hamilton - samhamilton

--- a/screen/HiveMindRoot/search.xml
+++ b/screen/HiveMindRoot/search.xml
@@ -166,7 +166,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <!-- this is a type=many relationship, but we just want one here: -->
                 <entity-find-related-one value-field="dataDocument" cache="true"
                         relationship-name="moqui.entity.document.DataDocumentLink" to-value-field="dataDocumentLink"/>
-                <set field="linkUrl" from="ec.resource.evaluateStringExpand(dataDocumentLink?.linkUrl, '')"/>
+                <set field="linkUrl" from="${ec.web.getWebappRootUrl(false, null)} + ec.resource.evaluateStringExpand(dataDocumentLink?.linkUrl, '')"/>
                 <set field="documentTitle" from="ec.resource.evaluateStringExpand(dataDocument?.documentTitle, '')"/>
             </row-actions>
             <field name="type"><default-field><display text="${dataDocument.documentName}"/></default-field></field>


### PR DESCRIPTION
URL uses absolute paths, so we need to add the root prefix when it is not the root application.