### PR TITLE
Summary fix

### DIFF
--- a/screen/HiveMindAdmin/Project/MilestoneSummary.xml
+++ b/screen/HiveMindAdmin/Project/MilestoneSummary.xml
@@ -38,6 +38,7 @@ along with this software (see the LICENSE.md file). If not, see
             <econdition field-name="workEffortTypeEnumId" value="WetTask"/>
             <econdition field-name="purposeEnumId" operator="not-equals" value="WepPlaceholder"/>
             <econdition field-name="statusId" operator="in" value="WeInPlanning,WeApproved,WeOnHold"/>
+            <date-filter/>
             <order-by field-name="priority"/><order-by field-name="estimatedCompletionDate"/>
         </entity-find>
         <entity-find entity-name="WorkEffortAssocAndTo" list="activeTaskList">
@@ -45,6 +46,7 @@ along with this software (see the LICENSE.md file). If not, see
             <econdition field-name="workEffortTypeEnumId" value="WetTask"/>
             <econdition field-name="purposeEnumId" operator="not-equals" value="WepPlaceholder"/>
             <econdition field-name="statusId" value="WeInProgress"/>
+            <date-filter/>
             <order-by field-name="priority"/><order-by field-name="estimatedCompletionDate"/>
         </entity-find>
         <entity-find entity-name="WorkEffortAssocAndTo" list="doneTaskList">
@@ -52,6 +54,7 @@ along with this software (see the LICENSE.md file). If not, see
             <econdition field-name="workEffortTypeEnumId" value="WetTask"/>
             <econdition field-name="purposeEnumId" operator="not-equals" value="WepPlaceholder"/>
             <econdition field-name="statusId" operator="in" value="WeComplete,WeClosed"/>
+            <date-filter/>
             <order-by field-name="priority"/><order-by field-name="estimatedCompletionDate"/>
         </entity-find>
     </actions>

--- a/screen/HiveMindRoot/Project/MilestoneSummary.xml
+++ b/screen/HiveMindRoot/Project/MilestoneSummary.xml
@@ -38,6 +38,7 @@ along with this software (see the LICENSE.md file). If not, see
             <econdition field-name="workEffortTypeEnumId" value="WetTask"/>
             <econdition field-name="purposeEnumId" operator="not-equals" value="WepPlaceholder"/>
             <econdition field-name="statusId" operator="in" value="WeInPlanning,WeApproved,WeOnHold"/>
+            <date-filter/>
             <order-by field-name="priority"/><order-by field-name="estimatedCompletionDate"/>
         </entity-find>
         <entity-find entity-name="WorkEffortAssocAndTo" list="activeTaskList">
@@ -45,6 +46,7 @@ along with this software (see the LICENSE.md file). If not, see
             <econdition field-name="workEffortTypeEnumId" value="WetTask"/>
             <econdition field-name="purposeEnumId" operator="not-equals" value="WepPlaceholder"/>
             <econdition field-name="statusId" value="WeInProgress"/>
+            <date-filter/>
             <order-by field-name="priority"/><order-by field-name="estimatedCompletionDate"/>
         </entity-find>
         <entity-find entity-name="WorkEffortAssocAndTo" list="doneTaskList">
@@ -52,6 +54,7 @@ along with this software (see the LICENSE.md file). If not, see
             <econdition field-name="workEffortTypeEnumId" value="WetTask"/>
             <econdition field-name="purposeEnumId" operator="not-equals" value="WepPlaceholder"/>
             <econdition field-name="statusId" operator="in" value="WeComplete,WeClosed"/>
+            <date-filter/>
             <order-by field-name="priority"/><order-by field-name="estimatedCompletionDate"/>
         </entity-find>
     </actions>


### PR DESCRIPTION
When changing milestones on tasks, the milestone summaries both in HiveMindRoot and HiveMindAdmin were showing old entries, some even duplicated, because of the lacking date-filter.