### PR TITLE
Avoid template error when project.actualWorkTime is null.

### DIFF
--- a/screen/HiveMindAdmin/dashboard.xml
+++ b/screen/HiveMindAdmin/dashboard.xml
@@ -212,7 +212,7 @@ along with this software (see the LICENSE.md file). If not, see
                                             <section name="TimeBudgetStats" condition="project.totalTimeAllowed"><widgets>
                                                 <container-row>
                                                     <row-col sm="4"><label text="Budget ${ec.l10n.format(project.totalTimeAllowed, '#.#')} hrs" type="strong"/></row-col>
-                                                    <row-col sm="4"><label text="Act Bgt Rem ${ec.l10n.format(project.totalTimeAllowed - project.actualWorkTime, '#.#')} hrs" type="strong" style="text-info"/></row-col>
+                                                    <row-col sm="4"><label text="Act Bgt Rem ${ec.l10n.format(project.totalTimeAllowed - (project.actualWorkTime?:0), '#.#')} hrs" type="strong" style="text-info"/></row-col>
                                                     <row-col sm="4"><label text="Est Bgt Rem ${ec.l10n.format(project.totalTimeAllowed - pstats.actualPlusRemainingTime, '#.#')} hrs" type="strong" style="${pstats.actualPlusRemainingOverTimeBudget ? 'text-danger' : 'text-success'}"/></row-col>
                                                 </container-row>
                                             </widgets></section>


### PR DESCRIPTION
Fixes following error when project.actualWorkTime is null (newly created project, has no time entries):

15:51:32.250 ERROR 029991479-11      o.moqui.i.c.r.FtlTemplateRenderer Error from code called in FTL render
java.lang.IllegalArgumentException: Error in string expression ["""Act Bgt Rem ${ec.l10n.format(project.totalTimeAllowed - ((Number)project.actualWorkTime), '#.#')} hrs"""] from 
        at org.moqui.impl.context.ResourceFacadeImpl.expand(ResourceFacadeImpl.groovy:492) ~[moqui-framework-2.0.0.jar:2.0.0]
...
Caused by: groovy.lang.GroovyRuntimeException: Ambiguous method overloading for method java.math.BigDecimal#minus.
Cannot resolve which method to invoke for [null] due to overlapping prototypes between:
        [class java.lang.Character]
        [class java.lang.Number]
        at S114c327a___Act_Bgt_Rem___ec_l10n_forma.run(S114c327a___Act_Bgt_Rem___ec_l10n_forma:1) ~[?:?]
        at org.moqui.impl.context.ResourceFacadeImpl.expand(ResourceFacadeImpl.groovy:488) ~[moqui-framework-2.0.0.jar:2.0.0]