### PR TITLE
Avoid duplicate Milestones when user has more than one role.

### DIFF
--- a/screen/HiveMindRoot/dashboard/MyMilestones.xml
+++ b/screen/HiveMindRoot/dashboard/MyMilestones.xml
@@ -20,7 +20,7 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="milestoneSummary"><default-response url="../../Project/MilestoneSummary"/></transition>
 
     <actions>
-        <entity-find entity-name="WorkEffortAndRootByParty" list="myMilestoneList">
+        <entity-find entity-name="WorkEffortAndRootByParty" list="myMilestoneList" distinct="true">
             <date-filter/>
             <econdition field-name="partyId" from="ec.user.userAccount.partyId"/>
             <econdition field-name="rootWorkEffortTypeEnumId" value="WetProject"/>


### PR DESCRIPTION
Example case: userId has Manager role and also VendorBillFrom role. In the example case, some projects are billed through the organization but others are billed directly by the person.