### PR TITLE
Improve team assignment support in several locations.

### DIFF
--- a/screen/HiveMindRoot/dashboard/MyMilestones.xml
+++ b/screen/HiveMindRoot/dashboard/MyMilestones.xml
@@ -22,7 +22,13 @@ along with this software (see the LICENSE.md file). If not, see
     <actions>
         <entity-find entity-name="WorkEffortAndRootByParty" list="myMilestoneList" distinct="true">
             <date-filter/>
-            <econdition field-name="partyId" from="ec.user.userAccount.partyId"/>
+            <econditions combine="or">
+                <econdition field-name="partyId" from="ec.user.userAccount.partyId"/>
+                <econditions>
+                    <date-filter from-field-name="teamRelationshipFromDate" thru-field-name="teamRelationshipThruDate"/>
+                    <econdition field-name="teamMemberPartyId" from="ec.user.userAccount.partyId"/>
+                </econditions>
+            </econditions>
             <econdition field-name="rootWorkEffortTypeEnumId" value="WetProject"/>
             <econdition field-name="rootStatusId" operator="not-in" value="WeClosed,WeCancelled"/>
             <econdition field-name="workEffortTypeEnumId" value="WetMilestone"/>

--- a/screen/HiveMindRoot/dashboard/MyProjects.xml
+++ b/screen/HiveMindRoot/dashboard/MyProjects.xml
@@ -23,7 +23,16 @@ along with this software (see the LICENSE.md file). If not, see
             <entity-find entity-name="mantle.work.effort.WorkEffortAndParty" list="myProjectList" distinct="true">
                 <econditions combine="or">
                     <econdition field-name="visibilityEnumId" operator="in" value="WevGeneral,WevAllUsers"/>
-                    <econditions><date-filter/><econdition field-name="partyId" from="ec.user.userAccount.partyId"/></econditions>
+                    <econditions>
+                        <date-filter/>
+                        <econditions combine="or">
+                            <econdition field-name="partyId" from="ec.user.userAccount.partyId"/>
+                            <econditions>
+                                <date-filter from-field-name="teamRelationshipFromDate" thru-field-name="teamRelationshipThruDate"/>
+                                <econdition field-name="teamMemberPartyId" from="ec.user.userAccount.partyId"/>
+                            </econditions>
+                        </econditions>
+                    </econditions>
                 </econditions>
                 <econdition field-name="workEffortTypeEnumId" value="WetProject"/>
                 <select-field field-name="workEffortId,workEffortName,estimatedStartDate,statusId"/>

--- a/screen/HiveMindRoot/dashboard/MyRequests.xml
+++ b/screen/HiveMindRoot/dashboard/MyRequests.xml
@@ -36,7 +36,13 @@ along with this software (see the LICENSE.md file). If not, see
                 <form-list name="MyRequests" list="myRequestList">
                     <entity-find entity-name="mantle.request.RequestAndParty" list="myRequestList" distinct="true">
                         <date-filter/>
-                        <econdition field-name="partyId" from="ec.user.userAccount.partyId"/>
+                        <econditions combine="or">
+                            <econdition field-name="partyId" from="ec.user.userAccount.partyId"/>
+                            <econditions>
+                                <date-filter from-field-name="teamRelationshipFromDate" thru-field-name="teamRelationshipThruDate"/>
+                                <econdition field-name="teamMemberPartyId" from="ec.user.userAccount.partyId"/>
+                            </econditions>
+                        </econditions>
                         <econdition field-name="statusId" operator="not-in" value="ReqCompleted,ReqCancelled"/>
                         <select-field field-name="requestName"/><order-by field-name="priority"/>
                     </entity-find>

--- a/screen/HiveMindRoot/dashboard/MyTasks.xml
+++ b/screen/HiveMindRoot/dashboard/MyTasks.xml
@@ -69,7 +69,14 @@ along with this software (see the LICENSE.md file). If not, see
             </box-toolbar><box-body>
                 <form-list name="MyTasks" list="myTaskList">
                     <entity-find entity-name="mantle.work.effort.PartyTaskSummary" list="myTaskList" distinct="true">
-                        <date-filter/><econdition field-name="partyId" from="ec.user.userAccount.partyId"/>
+                        <date-filter/>
+                        <econditions combine="or">
+                            <econdition field-name="partyId" from="ec.user.userAccount.partyId"/>
+                            <econditions>
+                                <date-filter from-field-name="teamRelationshipFromDate" thru-field-name="teamRelationshipThruDate"/>
+                                <econdition field-name="teamMemberPartyId" from="ec.user.userAccount.partyId"/>
+                            </econditions>
+                        </econditions>
                         <econdition field-name="statusId" operator="not-in" value="WeClosed,WeCancelled"/>
                         <econdition field-name="purposeEnumId" operator="not-equals" value="WepPlaceholder"/>
                         <econdition field-name="partyStatusId" operator="in" value="WeptAssigned,WeptArrived"/>


### PR DESCRIPTION
This makes use of changes in mantle-usl for teamAssignments, and does the proper entity-finds against teamMemberPartyId.  With these changes, a logged-in user will be able to see Tasks, Projects, Milestones(inherited via Projects) and Requests that have been only assigned to a team, that the current user is a member of.

Requires moqui/mantle-usl#208